### PR TITLE
JDTB-31 Remove ID column from log grid

### DIFF
--- a/view/adminhtml/ui_component/log_listing.xml
+++ b/view/adminhtml/ui_component/log_listing.xml
@@ -41,16 +41,12 @@
     </listingToolbar>
 
     <columns name="log_columns" class="Magento\Ui\Component\Listing\Columns">
-        <selectionsColumn name="ids" sortOrder="0">
+        <column name="timestamp" class="Magento\Ui\Component\Listing\Columns\Date"
+                component="Magento_Ui/js/grid/columns/date" sortOrder="10">
             <settings>
-                <indexField>logger_id</indexField>
-            </settings>
-        </selectionsColumn>
-        <column name="logger_id" sortOrder="10">
-            <settings>
-                <filter>textRange</filter>
-                <label translate="true">ID</label>
-                <sorting>desc</sorting>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <label translate="true">Timestamp</label>
             </settings>
         </column>
 
@@ -79,15 +75,6 @@
             <settings>
                 <filter>text</filter>
                 <label translate="true">Identifier value</label>
-            </settings>
-        </column>
-
-        <column name="timestamp" class="Magento\Ui\Component\Listing\Columns\Date"
-                component="Magento_Ui/js/grid/columns/date" sortOrder="60">
-            <settings>
-                <filter>dateRange</filter>
-                <dataType>date</dataType>
-                <label translate="true">Timestamp</label>
             </settings>
         </column>
     </columns>


### PR DESCRIPTION
**Ticket:** https://wearejh.atlassian.net/browse/JDTB-31

**Description:**
- Remove ID column from log grid 
- Move timestamp column in first place so it would be easy for a user to understand that this column can be use for sorting
