### PR TITLE
Fix PHP 8.4 implicit nullable parameter deprecations

### DIFF
--- a/Api/LoggerManagementInterface.php
+++ b/Api/LoggerManagementInterface.php
@@ -23,7 +23,7 @@ interface LoggerManagementInterface
         string $identifierValue = '',
         int $severity = 1,
         bool $createIssue = true,
-        \Exception $exception = null
+        ?\Exception $exception = null
     ): bool;
 
     /**

--- a/Service/LoggerManagement.php
+++ b/Service/LoggerManagement.php
@@ -70,7 +70,7 @@ class LoggerManagement implements LoggerManagementInterface
         string $identifierValue = '',
         int $severity = 1,
         bool $createIssue = true,
-        \Exception $exception = null
+        ?\Exception $exception = null
     ): bool {
         $issueId = 0;
         if ($createIssue === true) {
@@ -113,7 +113,7 @@ class LoggerManagement implements LoggerManagementInterface
      * @return bool|int
      * @throws \Exception
      */
-    private function createIssue(string $type, string $message, \Exception $exception = null)
+    private function createIssue(string $type, string $message, ?\Exception $exception = null)
     {
         if ($issueId = $this->issueManagement->isOpen($type)) {
             return $issueId;


### PR DESCRIPTION
Add explicit nullable type declarations (?Type) to parameters with null defaults to resolve PHP 8.4 deprecation warnings.